### PR TITLE
Expose dependent types transitively

### DIFF
--- a/annot8-common/annot8-common-components/src/main/java/module-info.java
+++ b/annot8-common/annot8-common-components/src/main/java/module-info.java
@@ -1,7 +1,7 @@
 open module io.annot8.common.components {
   requires transitive io.annot8.api;
-  requires org.slf4j;
-  requires micrometer.core;
+  requires transitive org.slf4j;
+  requires transitive micrometer.core;
   requires jakarta.json.bind;
   requires io.annot8.common.data;
 


### PR DESCRIPTION
Some types from metrics and slf4j are transitively exposed as they appear on the API surface.
Clients can use these types directly, but it is recommended to use the exposed types instead and simplify the dependency hierarchy.