### PR TITLE
Close pipeline on stop in InMemoryPipelineDescriptorRunner

### DIFF
--- a/annot8-implementations/annot8-pipeline-implementation/src/main/java/io/annot8/implementations/pipeline/SimplePipeline.java
+++ b/annot8-implementations/annot8-pipeline-implementation/src/main/java/io/annot8/implementations/pipeline/SimplePipeline.java
@@ -282,11 +282,13 @@ public class SimplePipeline implements Pipeline {
 
   protected void remove(Processor processor) {
     processors.remove(processor);
+    processor.close();
   }
 
   protected void remove(Source source) {
     sourceIndex++;
     sources.remove(source);
+    source.close();
   }
 
   public void close() {


### PR DESCRIPTION
The InMemoryPipelineDescriptorRunner effectively owns the Pipeline,
as it is created in the Builder and does not give any access to it.
Therefore, I suggest, it should be responsible for closing the pipeline.

In other implementations the closing could be managed differently.
Say you want to be able to stop and start the pipeline without clearing
caches or closing resources, but this would require a different approach.

This can be made more explicit in the usage by making the
InMemoryPipelineDescriptorRunner constructor private. So it is always
created through the builder and always owns the pipeline. This has been
done in this change but may be a step too far if this is considered stable API.