### PR TITLE
Close pipeline on stop in InMemoryPipelineDescriptorRunner

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -8,10 +8,14 @@ name: "CodeQL"
 on:
   workflow_dispatch:
   push:
-    branches: [master]
+    branches:
+      - main
+      - develop
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [master]
+    branches:
+      - main
+      - develop
   schedule:
     - cron: "0 20 * * 0"
 

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -6,9 +6,13 @@ name: Java CI with Maven
 on:
   workflow_dispatch:
   push:
-    branches: [master]
+    branches:
+      - main
+      - develop
   pull_request:
-    branches: [master]
+    branches:
+      - main
+      - develop
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}

--- a/annot8-implementations/annot8-pipeline-implementation/src/main/java/io/annot8/implementations/pipeline/SimplePipeline.java
+++ b/annot8-implementations/annot8-pipeline-implementation/src/main/java/io/annot8/implementations/pipeline/SimplePipeline.java
@@ -288,17 +288,19 @@ public class SimplePipeline implements Pipeline {
 
   protected void remove(Processor processor) {
     processors.remove(processor);
+    processor.close();
   }
 
   protected void remove(Source source) {
     int idx = sources.indexOf(source);
     sources.set(idx, null);
+    source.close();
   }
 
   public void close() {
-    sources.stream().forEach(Source::close);
-    processors.stream().forEach(Processor::close);
-    context.getResources().forEach(Resource::close);
+    sources.stream().filter(Objects::nonNull).forEach(Source::close);
+    processors.stream().filter(Objects::nonNull).forEach(Processor::close);
+    context.getResources().filter(Objects::nonNull).forEach(Resource::close);
   }
 
   public static class Builder implements Pipeline.Builder {

--- a/annot8-implementations/annot8-pipeline-implementation/src/test/java/io/annot8/implementations/pipeline/InMemoryPipelineRunnerTest.java
+++ b/annot8-implementations/annot8-pipeline-implementation/src/test/java/io/annot8/implementations/pipeline/InMemoryPipelineRunnerTest.java
@@ -4,6 +4,7 @@ package io.annot8.implementations.pipeline;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -20,10 +21,12 @@ import io.annot8.api.data.Item;
 import io.annot8.api.data.ItemFactory;
 import io.annot8.api.pipelines.PipelineDescriptor;
 import java.util.Arrays;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 import org.mockito.stubbing.Answer;
 
-public class InMemoryPipelineDescriptorRunnerTest {
+public class InMemoryPipelineRunnerTest {
 
   @Test
   public void test() {
@@ -83,6 +86,7 @@ public class InMemoryPipelineDescriptorRunnerTest {
 
     SourceDescriptor sd1 = mock(SourceDescriptor.class);
     when(sd1.create(any(Context.class))).thenReturn(source1);
+
     SourceDescriptor sd2 = mock(SourceDescriptor.class);
     when(sd2.create(any(Context.class))).thenReturn(source2);
 
@@ -112,12 +116,18 @@ public class InMemoryPipelineDescriptorRunnerTest {
     verify(processor1, times(5)).process(any());
     verify(processor2, times(3)).process(any());
 
-    runner.stop();
     assertFalse(runner.isRunning());
+
+    verify(source1, times(1)).close();
+    verify(source2, times(1)).close();
+    verify(processor1, times(1)).close();
+    verify(processor2, times(1)).close();
   }
 
   @Test
-  public void testOnThread() {
+  public void testOnThread() throws InterruptedException {
+    CountDownLatch countDownLatch = new CountDownLatch(2);
+
     ItemFactory itemFactory = mock(ItemFactory.class);
     when(itemFactory.create()).thenReturn(mock(Item.class));
 
@@ -153,6 +163,13 @@ public class InMemoryPipelineDescriptorRunnerTest {
                   invocationOnMock.getArgument(0, ItemFactory.class).create();
                   return SourceResponse.done();
                 });
+    doAnswer(
+            invocation -> {
+              countDownLatch.countDown();
+              return null;
+            })
+        .when(source1)
+        .close();
 
     Processor processor1 = mock(Processor.class);
     when(processor1.process(any()))
@@ -162,6 +179,13 @@ public class InMemoryPipelineDescriptorRunnerTest {
             ProcessorResponse.ok(),
             ProcessorResponse.ok(),
             ProcessorResponse.ok());
+    doAnswer(
+            invocation -> {
+              countDownLatch.countDown();
+              return null;
+            })
+        .when(processor1)
+        .close();
 
     SourceDescriptor sd1 = mock(SourceDescriptor.class);
     when(sd1.create(any(Context.class))).thenReturn(source1);
@@ -186,5 +210,6 @@ public class InMemoryPipelineDescriptorRunnerTest {
     assertTrue(runner.isRunning());
     runner.stop();
     assertFalse(runner.isRunning());
+    countDownLatch.await(1000, TimeUnit.MILLISECONDS);
   }
 }


### PR DESCRIPTION
The InMemoryPipelinerRunner effectively owns the Pipeline,
as it is created in the Builder and does not give any access to it.
Therefore, I suggest, it should be responsible for closing the pipeline.

In other implementations the closing could be managed differently.
Say you want to be able to stop and start the pipeline without clearing
caches or closing resources, but this would require a different approach.

This can be made more explicit in the usage by making the
InMemoryPipelineRunner constructor private. So it is always
created through the builder and always owns the pipeline. This has been
deprecated so it can be made private later.